### PR TITLE
Add linked element selector with modeless UI

### DIFF
--- a/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
@@ -51,6 +51,12 @@ namespace LinkedIdSelector.ExternalEventsModeless
                                 break;
                             }
 
+                        case RevitRequestId.SelectLinkedElement:
+                            {
+                                _modelessCommands.SelectLinkedElement(uiapp, _itemStore);
+                                break;
+                            }
+
                         default:
                             {
                                 break;

--- a/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
@@ -1,5 +1,7 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using LinkedIdSelector.Model;
 using LinkedIdSelector.Stores;
 
 namespace LinkedIdSelector.ExternalEventsModeless
@@ -16,7 +18,29 @@ namespace LinkedIdSelector.ExternalEventsModeless
             TaskDialog.Show("Message", "This is a sample message");
 
             trans.Commit();
+        }
 
+        public void SelectLinkedElement(UIApplication uiapp, ItemStore itemstore)
+        {
+            UIDocument uidoc = uiapp.ActiveUIDocument;
+            try
+            {
+                Reference reference = uidoc.Selection.PickObject(ObjectType.LinkedElement, "Select element in a linked model");
+                if (reference == null) return;
+
+                RevitLinkInstance linkInstance = uidoc.Document.GetElement(reference) as RevitLinkInstance;
+                if (linkInstance == null) return;
+
+                ElementId linkedElementId = reference.LinkedElementId;
+                string linkName = linkInstance.Name;
+
+                itemstore.LinkedElementInfos.Add(new LinkedElementInfo(linkedElementId.IntegerValue, linkName));
+                itemstore.AddLogToInterface($"Selected {linkedElementId.IntegerValue} from {linkName}");
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            {
+                itemstore.AddLogToInterface("Selection canceled");
+            }
         }
     }
 }

--- a/LinkedIdSelector/ExternalEventsModeless/RevitRequest.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/RevitRequest.cs
@@ -24,6 +24,7 @@ namespace LinkedIdSelector.ExternalEventsModeless
     {
         None = 0,
         SampleRequest = 1,
+        SelectLinkedElement = 2,
 
     }
 }

--- a/LinkedIdSelector/Model/LinkedElementInfo.cs
+++ b/LinkedIdSelector/Model/LinkedElementInfo.cs
@@ -1,0 +1,16 @@
+using Autodesk.Revit.DB;
+
+namespace LinkedIdSelector.Model
+{
+    public class LinkedElementInfo
+    {
+        public int ElementId { get; set; }
+        public string LinkName { get; set; }
+
+        public LinkedElementInfo(int elementId, string linkName)
+        {
+            ElementId = elementId;
+            LinkName = linkName;
+        }
+    }
+}

--- a/LinkedIdSelector/Stores/ItemStore.cs
+++ b/LinkedIdSelector/Stores/ItemStore.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Autodesk.Revit.DB;
+using LinkedIdSelector.Model;
 
 namespace LinkedIdSelector.Stores
 {
@@ -22,6 +24,7 @@ namespace LinkedIdSelector.Stores
         }
 
         public List<ElementId> ElementIdsInCurrentView { get; set; } = new List<ElementId>();
+        public ObservableCollection<LinkedElementInfo> LinkedElementInfos { get; } = new ObservableCollection<LinkedElementInfo>();
         public ItemStore() { }
 
 

--- a/LinkedIdSelector/View/MainView.xaml
+++ b/LinkedIdSelector/View/MainView.xaml
@@ -2,7 +2,6 @@
     x:Class="LinkedIdSelector.View.MainView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:components="clr-namespace:LinkedIdSelector.View"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:LinkedIdSelector.ViewModel"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -51,11 +50,25 @@
                 Text="Sample Tool" />
         </StackPanel>
 
-        <components:DataGrid
+        <DataGrid
             Grid.Row="1"
             Grid.RowSpan="3"
             Grid.Column="0"
-            DataContext="{Binding DataGridViewModel}" />
+            ItemsSource="{Binding LinkedElements}"
+            AutoGenerateColumns="False"
+            CellStyle="{StaticResource CustomCellStyle}"
+            ColumnHeaderStyle="{StaticResource ModernColumnHeaderStyle}"
+            GridLinesVisibility="None"
+            RowStyle="{StaticResource CustomRowStyle}"
+            ScrollViewer.CanContentScroll="True"
+            ScrollViewer.HorizontalScrollBarVisibility="Auto"
+            ScrollViewer.VerticalScrollBarVisibility="Auto"
+            Style="{StaticResource ModernDataGridStyle}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding ElementId}" Header="Revit Id" />
+                <DataGridTextColumn Binding="{Binding LinkName}" Header="Link Name" />
+            </DataGrid.Columns>
+        </DataGrid>
 
         <!--  SPACER BETWEEN THE LEGENDA AND THE DATA GRID  -->
         <StackPanel Grid.Column="1" Margin="10" />
@@ -91,6 +104,11 @@
                 Margin="10"
                 Command="{Binding RunScriptCommand}"
                 Content="Run Script" />
+            <Button
+                Width="100"
+                Margin="10"
+                Command="{Binding SelectLinkedElementCommand}"
+                Content="Select Element" />
             <Button
                 Width="100"
                 Margin="10"

--- a/LinkedIdSelector/ViewModel/MainViewModel.cs
+++ b/LinkedIdSelector/ViewModel/MainViewModel.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+using System.Collections.ObjectModel;
+using System.IO;
 using System.Windows.Input;
 using Autodesk.Revit.DB;
 using LinkedIdSelector.Commands;
 using LinkedIdSelector.ExternalEventsModeless;
+using LinkedIdSelector.Model;
 using LinkedIdSelector.Stores;
 using Microsoft.Win32;
 
@@ -13,9 +15,12 @@ namespace LinkedIdSelector.ViewModel
         private Document _doc { get; set; }
         private RevitExternalEvents _revitExternalEvent;
         public ICommand RunScriptCommand { get; }
+        public ICommand SelectLinkedElementCommand { get; }
+        public ICommand LoadFileCommand { get; }
         public ItemStore ItemStore { get; private set; }
 
         public DataGridViewModel DataGridViewModel { get; private set; }
+        public ObservableCollection<LinkedElementInfo> LinkedElements { get; }
 
         private string _logMessageForInterface;
         public string LogMessageForInterface
@@ -63,7 +68,10 @@ namespace LinkedIdSelector.ViewModel
             ItemStore.LogMessageChanged += OnLogMessageChanged;
             _doc = doc;
             DataGridViewModel = new DataGridViewModel(this);
+            LinkedElements = ItemStore.LinkedElementInfos;
             RunScriptCommand = new RelayCommand(x => RunExampleScript());
+            SelectLinkedElementCommand = new RelayCommand(x => _revitExternalEvent.MakeRequest(RevitRequestId.SelectLinkedElement));
+            LoadFileCommand = new RelayCommand(x => RunLoadExcelCommand());
         }
 
         public bool SetFilePath()


### PR DESCRIPTION
## Summary
- Let users pick elements from Revit links and capture linked element id and link name
- Display picked elements in a modeless WPF grid styled like existing UI
- Wire up external event requests and storage for linked selections

## Testing
- `dotnet build LinkedIdSelector.sln -c "Debug 2025"` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac7014fc832c8188beafce872a60