### PR TITLE
Add linked element selector with modeless UI

### DIFF
--- a/LinkedIdSelector/App.cs
+++ b/LinkedIdSelector/App.cs
@@ -15,7 +15,6 @@ namespace LinkedIdSelector
     public class App : IExternalCommand
     {
         private MainView _mainView { get; set; }
-        private Document _doc;
         private ItemStore _itemStore;
         private RevitExternalEvents _revitExternalEvents;
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
@@ -31,16 +30,14 @@ namespace LinkedIdSelector
             NLogger.Setup();
             _logger.Info("------------------------------------------------");
             _logger.Info("LinkedIdSelector is gestart. \n");
-            _itemStore.AddLogToInterface("LinkedIdSelector is gestart");
 
-            _doc = commandData.Application.ActiveUIDocument.Document;
             try
             {
                 if (_mainView == null)
                 {
                     _mainView = new MainView()
                     {
-                        DataContext = new MainViewModel(_doc, _revitExternalEvents, _itemStore)
+                        DataContext = new MainViewModel(_revitExternalEvents, _itemStore)
                     };
 
                     _mainView.Closed += new EventHandler(ClosingMainView);

--- a/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
@@ -51,6 +51,12 @@ namespace LinkedIdSelector.ExternalEventsModeless
                                 break;
                             }
 
+                        case RevitRequestId.SelectLinkedElement:
+                            {
+                                _modelessCommands.SelectLinkedElement(uiapp, _itemStore);
+                                break;
+                            }
+
                         default:
                             {
                                 break;

--- a/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
@@ -1,5 +1,7 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using LinkedIdSelector.Model;
 using LinkedIdSelector.Stores;
 
 namespace LinkedIdSelector.ExternalEventsModeless
@@ -12,11 +14,30 @@ namespace LinkedIdSelector.ExternalEventsModeless
             Transaction trans = new Transaction(doc);
             trans.Start("StartSanpleCommand");
 
-            itemstore.AddLogToInterface("the button was clicked");
             TaskDialog.Show("Message", "This is a sample message");
 
             trans.Commit();
+        }
 
+        public void SelectLinkedElement(UIApplication uiapp, ItemStore itemstore)
+        {
+            UIDocument uidoc = uiapp.ActiveUIDocument;
+            try
+            {
+                Reference reference = uidoc.Selection.PickObject(ObjectType.LinkedElement, "Select element in a linked model");
+                if (reference == null) return;
+
+                RevitLinkInstance linkInstance = uidoc.Document.GetElement(reference) as RevitLinkInstance;
+                if (linkInstance == null) return;
+
+                ElementId linkedElementId = reference.LinkedElementId;
+                string linkName = linkInstance.Document.Title;
+
+                itemstore.LinkedElementInfos.Add(new LinkedElementInfo(linkedElementId.IntegerValue, linkName));
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            {
+            }
         }
     }
 }

--- a/LinkedIdSelector/ExternalEventsModeless/RevitRequest.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/RevitRequest.cs
@@ -24,6 +24,7 @@ namespace LinkedIdSelector.ExternalEventsModeless
     {
         None = 0,
         SampleRequest = 1,
+        SelectLinkedElement = 2,
 
     }
 }

--- a/LinkedIdSelector/Model/LinkedElementInfo.cs
+++ b/LinkedIdSelector/Model/LinkedElementInfo.cs
@@ -1,0 +1,16 @@
+using Autodesk.Revit.DB;
+
+namespace LinkedIdSelector.Model
+{
+    public class LinkedElementInfo
+    {
+        public int ElementId { get; set; }
+        public string LinkName { get; set; }
+
+        public LinkedElementInfo(int elementId, string linkName)
+        {
+            ElementId = elementId;
+            LinkName = linkName;
+        }
+    }
+}

--- a/LinkedIdSelector/Stores/ItemStore.cs
+++ b/LinkedIdSelector/Stores/ItemStore.cs
@@ -1,39 +1,16 @@
-﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Autodesk.Revit.DB;
+using LinkedIdSelector.Model;
 
 namespace LinkedIdSelector.Stores
 {
     public class ItemStore
     {
-        private string _logMessageForInterfaceItemStore;
-
-        public string LogMessageForInterfaceItemStore
-        {
-            get => _logMessageForInterfaceItemStore;
-            set
-            {
-                if (_logMessageForInterfaceItemStore != value)
-                {
-                    _logMessageForInterfaceItemStore = value;
-                    LogMessageChanged?.Invoke(value);
-                }
-            }
-        }
-
         public List<ElementId> ElementIdsInCurrentView { get; set; } = new List<ElementId>();
+        public ObservableCollection<LinkedElementInfo> LinkedElementInfos { get; } = new ObservableCollection<LinkedElementInfo>();
+
         public ItemStore() { }
-
-
-
-        public void AddLogToInterface(string logMessage) => LogMessageForInterfaceItemStore = LogMessageForInterfaceItemStore + logMessage + "\n \n";
-
-        public event Action<string> LogMessageChanged;
-
-
-
-
-
-
     }
 }
+

--- a/LinkedIdSelector/View/MainView.xaml
+++ b/LinkedIdSelector/View/MainView.xaml
@@ -1,8 +1,7 @@
-﻿<Window
+<Window
     x:Class="LinkedIdSelector.View.MainView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:components="clr-namespace:LinkedIdSelector.View"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:LinkedIdSelector.ViewModel"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -11,6 +10,7 @@
     d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
     Background="{DynamicResource ApplicationBackGround}"
     SizeToContent="WidthAndHeight"
+    Topmost="True"
     mc:Ignorable="d">
 
     <Window.Resources>
@@ -22,27 +22,14 @@
     </Window.Resources>
 
     <Grid Margin="10">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="20" />
-            <ColumnDefinition Width="300" />
-        </Grid.ColumnDefinitions>
-
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel
-            Grid.Row="0"
-            Grid.Column="0"
-            Grid.ColumnSpan="3"
-            Height="50"
-            Orientation="Horizontal">
-            <!--<Image Margin="0,8" Source="pack://application:,,,/LinkedIdSelector;component/Resources/BamLogoGreen.png" />-->
+        <StackPanel Grid.Row="0" Height="50" Orientation="Horizontal">
             <Image Margin="0,8" Source="/LinkedIdSelector;component/Resources/BamLogoGreen.png" />
-
             <TextBlock
                 Margin="10,0,0,0"
                 VerticalAlignment="Center"
@@ -51,51 +38,41 @@
                 Text="Sample Tool" />
         </StackPanel>
 
-        <components:DataGrid
+        <DataGrid
             Grid.Row="1"
-            Grid.RowSpan="3"
-            Grid.Column="0"
-            DataContext="{Binding DataGridViewModel}" />
+            ItemsSource="{Binding LinkedElements}"
+            AutoGenerateColumns="False"
+            CellStyle="{StaticResource CustomCellStyle}"
+            ColumnHeaderStyle="{StaticResource ModernColumnHeaderStyle}"
+            GridLinesVisibility="None"
+            RowStyle="{StaticResource CustomRowStyle}"
+            ScrollViewer.CanContentScroll="True"
+            ScrollViewer.HorizontalScrollBarVisibility="Auto"
+            ScrollViewer.VerticalScrollBarVisibility="Auto"
+            Style="{StaticResource ModernDataGridStyle}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding ElementId}" Header="Revit Id" />
+                <DataGridTextColumn Binding="{Binding LinkName}" Header="Link Name" />
+                <DataGridTemplateColumn Header="Copy">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button
+                                Content="Copy"
+                                Command="{Binding DataContext.CopyElementIdCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                CommandParameter="{Binding ElementId}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
 
-        <!--  SPACER BETWEEN THE LEGENDA AND THE DATA GRID  -->
-        <StackPanel Grid.Column="1" Margin="10" />
-
-        <Grid Grid.Row="1" Grid.Column="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-
-            <Label Content="Logging screen" />
-            <TextBlock
-                Grid.Row="1"
-                VerticalAlignment="Stretch"
-                Background="White"
-                Text="{Binding LogMessageForInterface}" />
-        </Grid>
-
-        <StackPanel
-            Grid.Row="2"
-            Grid.Column="0"
-            Grid.ColumnSpan="3"
-            Height="150"
-            HorizontalAlignment="Right"
-            Orientation="Vertical">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button
                 Width="100"
                 Margin="10"
-                Command="{Binding LoadFileCommand}"
-                Content="Load File" />
-            <Button
-                Width="100"
-                Margin="10"
-                Command="{Binding RunScriptCommand}"
-                Content="Run Script" />
-            <Button
-                Width="100"
-                Margin="10"
-                Content="Cancel" />
-
+                Command="{Binding SelectLinkedElementCommand}"
+                Content="Select Element" />
         </StackPanel>
     </Grid>
 </Window>
+


### PR DESCRIPTION
## Summary
- Keep modeless window always on top and streamline controls to the select element action
- Copy element IDs to the clipboard from each grid row and fetch link names via the link document title
- Remove unused buttons and logging infrastructure for a cleaner interface

## Testing
- `dotnet build LinkedIdSelector.sln -c "Debug 2025"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac7014fc832c8188beafce872a60