### PR TITLE
Implement current view filtering support

### DIFF
--- a/LinkedIdSelector/Stores/ItemStore.cs
+++ b/LinkedIdSelector/Stores/ItemStore.cs
@@ -23,7 +23,7 @@ namespace LinkedIdSelector.Stores
             }
         }
 
-        public List<ElementId> ElementIdsInCurrentView { get; set; } = new List<ElementId>();
+        public List<ElementId> ElementIdsInCurrentView { get; } = new List<ElementId>();
         public ObservableCollection<LinkedElementInfo> LinkedElementInfos { get; } = new ObservableCollection<LinkedElementInfo>();
         public ItemStore() { }
 

--- a/LinkedIdSelector/ViewModel/DataGridViewModel.cs
+++ b/LinkedIdSelector/ViewModel/DataGridViewModel.cs
@@ -41,8 +41,15 @@ namespace LinkedIdSelector.ViewModel
                 _filterByView = value;
                 OnPropertyChanged(nameof(FilterByView));
 
-                // Example filter
-                //if (value == true) _mainViewModel.GetElementsInCurrentView();
+                if (value)
+                {
+                    _mainViewModel.GetElementsInCurrentView();
+                }
+                else
+                {
+                    _itemStore.ElementIdsInCurrentView.Clear();
+                }
+
                 FilteredItems.Refresh();
             }
         }

--- a/LinkedIdSelector/ViewModel/MainViewModel.cs
+++ b/LinkedIdSelector/ViewModel/MainViewModel.cs
@@ -122,6 +122,15 @@ namespace LinkedIdSelector.ViewModel
 
         }
 
+        public void GetElementsInCurrentView()
+        {
+            ItemStore.ElementIdsInCurrentView.Clear();
+            if (_doc?.ActiveView == null) return;
+
+            var collector = new FilteredElementCollector(_doc, _doc.ActiveView.Id);
+            ItemStore.ElementIdsInCurrentView.AddRange(collector.ToElementIds());
+        }
+
         public void LoadData()
         {
 


### PR DESCRIPTION
## Summary
- Populate `ItemStore.ElementIdsInCurrentView` via `MainViewModel.GetElementsInCurrentView`
- Refresh DataGrid view by current view and clear IDs when disabled
- Tighten `ElementIdsInCurrentView` definition

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc721698832cb2b5f83da3cc5b71