### PR TITLE
Use ElementId object in LinkedElementInfo

### DIFF
--- a/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
@@ -34,7 +34,7 @@ namespace LinkedIdSelector.ExternalEventsModeless
                 ElementId linkedElementId = reference.LinkedElementId;
                 string linkName = linkInstance.Name;
 
-                itemstore.LinkedElementInfos.Add(new LinkedElementInfo(linkedElementId.IntegerValue, linkName));
+                itemstore.LinkedElementInfos.Add(new LinkedElementInfo(linkedElementId, linkName));
                 itemstore.AddLogToInterface($"Selected {linkedElementId.IntegerValue} from {linkName}");
             }
             catch (Autodesk.Revit.Exceptions.OperationCanceledException)

--- a/LinkedIdSelector/Model/LinkedElementInfo.cs
+++ b/LinkedIdSelector/Model/LinkedElementInfo.cs
@@ -4,10 +4,10 @@ namespace LinkedIdSelector.Model
 {
     public class LinkedElementInfo
     {
-        public int ElementId { get; set; }
+        public ElementId ElementId { get; set; }
         public string LinkName { get; set; }
 
-        public LinkedElementInfo(int elementId, string linkName)
+        public LinkedElementInfo(ElementId elementId, string linkName)
         {
             ElementId = elementId;
             LinkName = linkName;


### PR DESCRIPTION
## Summary
- store `Autodesk.Revit.DB.ElementId` directly in `LinkedElementInfo`
- create `LinkedElementInfo` instances using `ElementId` objects

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc7a31a8832c980ab380df3e8a36