### PR TITLE
Log errors in modeless Revit event handler

### DIFF
--- a/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/EventHandlerRevit.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Autodesk.Revit.UI;
 using LinkedIdSelector.Stores;
-
+using NLog;
 
 namespace LinkedIdSelector.ExternalEventsModeless
 {
@@ -9,6 +9,7 @@ namespace LinkedIdSelector.ExternalEventsModeless
     {
 
         private ItemStore _itemStore;
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         // The value of the latest request made by the modeless form 
         private RevitRequest m_request = new RevitRequest();
@@ -64,9 +65,10 @@ namespace LinkedIdSelector.ExternalEventsModeless
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-
+                _logger.Error(ex, "Error executing Revit event request");
+                TaskDialog.Show("LinkedIdSelector", ex.Message);
             }
         }
         public string GetName() => "Basic External EventHandler";


### PR DESCRIPTION
## Summary
- add NLog logger to `EventHandlerRevit` and display errors via `TaskDialog`

## Testing
- `xbuild LinkedIdSelector.sln` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc7d4b48832ca54530d36ebee7a9