### PR TITLE
Streamline LinkedIdSelector UI and add copy button

### DIFF
--- a/LinkedIdSelector/App.cs
+++ b/LinkedIdSelector/App.cs
@@ -31,7 +31,6 @@ namespace LinkedIdSelector
             NLogger.Setup();
             _logger.Info("------------------------------------------------");
             _logger.Info("LinkedIdSelector is gestart. \n");
-            _itemStore.AddLogToInterface("LinkedIdSelector is gestart");
 
             _doc = commandData.Application.ActiveUIDocument.Document;
             try

--- a/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
+++ b/LinkedIdSelector/ExternalEventsModeless/ModelessCommands.cs
@@ -20,14 +20,12 @@ namespace LinkedIdSelector.ExternalEventsModeless
                 if (linkInstance == null) return;
 
                 ElementId linkedElementId = reference.LinkedElementId;
-                string linkName = linkInstance.Name;
+                string linkName = linkInstance.Document.Title;
 
                 itemstore.LinkedElementInfos.Add(new LinkedElementInfo(linkedElementId, linkName));
-                itemstore.AddLogToInterface($"Selected {linkedElementId.IntegerValue} from {linkName}");
             }
             catch (Autodesk.Revit.Exceptions.OperationCanceledException)
             {
-                itemstore.AddLogToInterface("Selection canceled");
             }
         }
     }

--- a/LinkedIdSelector/Stores/ItemStore.cs
+++ b/LinkedIdSelector/Stores/ItemStore.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Autodesk.Revit.DB;
@@ -8,35 +7,8 @@ namespace LinkedIdSelector.Stores
 {
     public class ItemStore
     {
-        private string _logMessageForInterfaceItemStore;
-
-        public string LogMessageForInterfaceItemStore
-        {
-            get => _logMessageForInterfaceItemStore;
-            set
-            {
-                if (_logMessageForInterfaceItemStore != value)
-                {
-                    _logMessageForInterfaceItemStore = value;
-                    LogMessageChanged?.Invoke(value);
-                }
-            }
-        }
-
         public List<ElementId> ElementIdsInCurrentView { get; } = new List<ElementId>();
         public ObservableCollection<LinkedElementInfo> LinkedElementInfos { get; } = new ObservableCollection<LinkedElementInfo>();
         public ItemStore() { }
-
-
-
-        public void AddLogToInterface(string logMessage) => LogMessageForInterfaceItemStore = LogMessageForInterfaceItemStore + logMessage + "\n \n";
-
-        public event Action<string> LogMessageChanged;
-
-
-
-
-
-
     }
 }

--- a/LinkedIdSelector/View/MainView.xaml
+++ b/LinkedIdSelector/View/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="LinkedIdSelector.View.MainView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,6 +10,7 @@
     d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
     Background="{DynamicResource ApplicationBackGround}"
     SizeToContent="WidthAndHeight"
+    Topmost="True"
     mc:Ignorable="d">
 
     <Window.Resources>
@@ -21,12 +22,6 @@
     </Window.Resources>
 
     <Grid Margin="10">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="20" />
-            <ColumnDefinition Width="300" />
-        </Grid.ColumnDefinitions>
-
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
@@ -35,13 +30,9 @@
 
         <StackPanel
             Grid.Row="0"
-            Grid.Column="0"
-            Grid.ColumnSpan="3"
             Height="50"
             Orientation="Horizontal">
-            <!--<Image Margin="0,8" Source="pack://application:,,,/LinkedIdSelector;component/Resources/BamLogoGreen.png" />-->
             <Image Margin="0,8" Source="/LinkedIdSelector;component/Resources/BamLogoGreen.png" />
-
             <TextBlock
                 Margin="10,0,0,0"
                 VerticalAlignment="Center"
@@ -52,8 +43,6 @@
 
         <DataGrid
             Grid.Row="1"
-            Grid.RowSpan="3"
-            Grid.Column="0"
             ItemsSource="{Binding LinkedElements}"
             AutoGenerateColumns="False"
             CellStyle="{StaticResource CustomCellStyle}"
@@ -67,48 +56,24 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding ElementId}" Header="Revit Id" />
                 <DataGridTextColumn Binding="{Binding LinkName}" Header="Link Name" />
+                <DataGridTemplateColumn Header="Copy">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Copy"
+                                    Command="{Binding DataContext.CopyElementIdCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                    CommandParameter="{Binding ElementId}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
 
-        <!--  SPACER BETWEEN THE LEGENDA AND THE DATA GRID  -->
-        <StackPanel Grid.Column="1" Margin="10" />
-
-        <Grid Grid.Row="1" Grid.Column="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-
-            <Label Content="Logging screen" />
-            <TextBlock
-                Grid.Row="1"
-                VerticalAlignment="Stretch"
-                Background="White"
-                Text="{Binding LogMessageForInterface}" />
-        </Grid>
-
-        <StackPanel
+        <Button
             Grid.Row="2"
-            Grid.Column="0"
-            Grid.ColumnSpan="3"
-            Height="150"
+            Width="100"
+            Margin="10"
             HorizontalAlignment="Right"
-            Orientation="Vertical">
-            <Button
-                Width="100"
-                Margin="10"
-                Command="{Binding LoadFileCommand}"
-                Content="Load File" />
-            <Button
-                Width="100"
-                Margin="10"
-                Command="{Binding SelectLinkedElementCommand}"
-                Content="Select Element" />
-            <Button
-                Width="100"
-                Margin="10"
-                Content="Cancel" />
-
-        </StackPanel>
+            Command="{Binding SelectLinkedElementCommand}"
+            Content="Select Element" />
     </Grid>
 </Window>

--- a/LinkedIdSelector/ViewModel/MainViewModel.cs
+++ b/LinkedIdSelector/ViewModel/MainViewModel.cs
@@ -1,12 +1,11 @@
 using System.Collections.ObjectModel;
-using System.IO;
+using System.Windows;
 using System.Windows.Input;
 using Autodesk.Revit.DB;
 using LinkedIdSelector.Commands;
 using LinkedIdSelector.ExternalEventsModeless;
 using LinkedIdSelector.Model;
 using LinkedIdSelector.Stores;
-using Microsoft.Win32;
 
 namespace LinkedIdSelector.ViewModel
 {
@@ -15,109 +14,26 @@ namespace LinkedIdSelector.ViewModel
         private Document _doc { get; set; }
         private RevitExternalEvents _revitExternalEvent;
         public ICommand SelectLinkedElementCommand { get; }
-        public ICommand LoadFileCommand { get; }
+        public ICommand CopyElementIdCommand { get; }
         public ItemStore ItemStore { get; private set; }
 
-        public DataGridViewModel DataGridViewModel { get; private set; }
         public ObservableCollection<LinkedElementInfo> LinkedElements { get; }
-
-        private string _logMessageForInterface;
-        public string LogMessageForInterface
-        {
-            get => _logMessageForInterface;
-            set
-            {
-                _logMessageForInterface = value;
-                OnPropertyChanged(nameof(LogMessageForInterface));
-            }
-        }
-
-
-        private string _filePath;
-        public string FilePath
-        {
-            get => _filePath;
-            set
-            {
-                _filePath = value;
-                OnPropertyChanged(nameof(FilePath));
-            }
-        }
-
-        private bool _filePathExist;
-        public bool FilePathExist
-        {
-            get
-            {
-                return _filePathExist;
-            }
-            set
-            {
-                _filePathExist = value;
-                OnPropertyChanged(nameof(FilePathExist));
-            }
-        }
-
 
         public MainViewModel(Document doc, RevitExternalEvents externalEvent, ItemStore itemStore)
         {
             _revitExternalEvent = externalEvent;
             ItemStore = itemStore;
-            LogMessageForInterface = ItemStore.LogMessageForInterfaceItemStore;
-            ItemStore.LogMessageChanged += OnLogMessageChanged;
             _doc = doc;
-            DataGridViewModel = new DataGridViewModel(this);
+
             LinkedElements = ItemStore.LinkedElementInfos;
             SelectLinkedElementCommand = new RelayCommand(x => _revitExternalEvent.MakeRequest(RevitRequestId.SelectLinkedElement));
-            LoadFileCommand = new RelayCommand(x => RunLoadExcelCommand());
-        }
-
-        public bool SetFilePath()
-        {
-            OpenFileDialog openFileDialog = new OpenFileDialog();
-
-            if (AppSettings.Instance.FilePath != string.Empty)
+            CopyElementIdCommand = new RelayCommand(param =>
             {
-                try
+                if (param is ElementId id)
                 {
-                    openFileDialog.InitialDirectory = Path.GetDirectoryName(AppSettings.Instance.FilePath);
+                    Clipboard.SetText(id.IntegerValue.ToString());
                 }
-                catch
-                {
-                    openFileDialog.InitialDirectory = @"c:\";
-                }
-
-            }
-            else
-            {
-                openFileDialog.InitialDirectory = @"c:\";
-            }
-
-            openFileDialog.Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*";
-            openFileDialog.FilterIndex = 2;
-            openFileDialog.RestoreDirectory = true;
-            openFileDialog.ShowDialog();
-            string filePath = openFileDialog.FileName;
-
-            if (openFileDialog.FileName == string.Empty) return false;
-
-            AppSettings.Instance.FilePath = filePath;
-            AppSettings.Instance.Save();
-
-            FilePath = filePath;
-            System.Windows.Input.CommandManager.InvalidateRequerySuggested();
-
-            return true;
-        }
-
-        public void RunLoadExcelCommand()
-        {
-            if (SetFilePath())
-            {
-                LoadData();
-            }
-
-
+            });
         }
 
         public void GetElementsInCurrentView()
@@ -128,29 +44,5 @@ namespace LinkedIdSelector.ViewModel
             var collector = new FilteredElementCollector(_doc, _doc.ActiveView.Id);
             ItemStore.ElementIdsInCurrentView.AddRange(collector.ToElementIds());
         }
-
-        public void LoadData()
-        {
-
-        }
-
-
-        public void LoadExcelFileOnStartUp()
-        {
-            FilePath = AppSettings.Instance.FilePath;
-
-
-
-            if (File.Exists(FilePath))
-            {
-                LoadData();
-            }
-            else
-            {
-                FilePath = string.Empty;
-            }
-        }
-
-        private void OnLogMessageChanged(string message) => LogMessageForInterface = message;
     }
 }


### PR DESCRIPTION
## Summary
- Keep main window on top and simplify layout
- Remove unused buttons and logging panel
- Add per-row copy-to-clipboard for element IDs
- Use link instance document title for link name

## Testing
- `dotnet build LinkedIdSelector.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bfc09a74832c9a3fa686819b5370